### PR TITLE
refacto: moved repetitive trait functions into generics ones

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -2,7 +2,7 @@ mod file_handler;
 mod project;
 
 use clap::{Parser, Subcommand};
-use project::{node_js::NodeProject, rust::RustProject, scan_project_deps, Project};
+use project::{node_js::NodeProject, rust::RustProject, scan_project_deps};
 
 #[derive(Parser)]
 struct Cli {
@@ -26,8 +26,8 @@ fn main() {
         Some(Commands::All) => {
             todo!("Add project detection with the configured package name constant.")
         },
-        Some(Commands::NodeJS) => scan_project_deps(NodeProject::default()),
-        Some(Commands::Rust) => scan_project_deps(RustProject::default()),
+        Some(Commands::NodeJS) => scan_project_deps(NodeProject::new()),
+        Some(Commands::Rust) => scan_project_deps(RustProject::new()),
         None => {}
     }
 }

--- a/src/project/mod.rs
+++ b/src/project/mod.rs
@@ -9,33 +9,24 @@ pub mod node_js;
 pub mod rust;
 
 pub trait Project {
-    /// Default contrustor for a Project
-    /// Some informations could be changes likes accepeted_extensions for example this is why is
-    /// why structs implementing Project should have their own constructors too to change some
-    /// functionnalities
-    fn default() -> Self;
+    const DEPS_FILE: &str;
+    const ALLOWED_EXTENSIONS: &[&str];
+    const EXCLUDED_PATHS: &[&str];
 
-    /// Returns the number of dependency in the projet.
     fn parse_deps(&mut self, deps_file_content: &str) -> usize;
-
-    /// Check if a file is theorically a dependency importer
-    /// Meaning that the file should have extension, name or anything else matching the language.
-    fn should_scan_file(&self, file_name: &str) -> bool;
-
     fn deps(&self) -> &Vec<String>;
-
-    fn read_deps_file() -> String;
 }
 
 pub fn scan_project_deps<T: Project>(mut project: T) {
-    let deps_count = project.parse_deps(&T::read_deps_file());
+    // TODO improve error managment
+    let deps_count = project.parse_deps(&read_file_at_path(T::DEPS_FILE).unwrap());
     println!("{deps_count} packages found in current project.");
     let mut used_deps = HashSet::new();
 
     let mut scanned_file_count = 0usize;
     for entry in WalkDir::new(".") {
         let entry = entry.unwrap();
-        if entry.path().is_dir() || !project.should_scan_file(entry.path().to_str().unwrap()) {
+        if entry.path().is_dir() || !should_scan_file::<T>(entry.path().to_str().unwrap()) {
             continue;
         }
 
@@ -82,4 +73,54 @@ pub fn scan_project_deps<T: Project>(mut project: T) {
 
     println!("{} files scanned", scanned_file_count);
     println!("{} unused deps", deps_count - used_deps.len());
+}
+
+fn should_scan_file<T: Project>(file_path: &str) -> bool {
+    if file_path == "." {
+        return true;
+    }
+
+    for excluded in T::EXCLUDED_PATHS.iter() {
+        if file_path.contains(excluded) {
+            return false;
+        }
+    }
+
+    for ext in T::ALLOWED_EXTENSIONS.iter() {
+        if file_path.ends_with(&format!(".{ext}")) {
+            return true;
+        }
+    }
+
+    false
+}
+
+#[cfg(test)]
+mod projects_tests {
+    use super::{should_scan_file, node_js::NodeProject, rust::RustProject};
+
+    #[test]
+    fn node_js_should_scan_file() {
+        assert_eq!(should_scan_file::<NodeProject>("foo.js"), true);
+        assert_eq!(should_scan_file::<NodeProject>("foo.ts"), true);
+        assert_eq!(should_scan_file::<NodeProject>("foo.tsx"), true);
+        assert_eq!(should_scan_file::<NodeProject>("foo.jsx"), true);
+        assert_eq!(should_scan_file::<NodeProject>("foo.json"), true);
+        assert_eq!(should_scan_file::<NodeProject>("foo.scss"), true);
+        assert_eq!(should_scan_file::<NodeProject>("foo.sass"), true);
+        assert_eq!(should_scan_file::<NodeProject>("foo.rs"), false);
+        assert_eq!(should_scan_file::<NodeProject>("foo.jssx"), false);
+        assert_eq!(should_scan_file::<NodeProject>("package.json"), false);
+        assert_eq!(should_scan_file::<NodeProject>("foo/node_modules/foo.ts"), false);
+    }
+
+    #[test]
+    fn rust_should_scan_file() {
+        assert_eq!(should_scan_file::<RustProject>("foo.rs"), true);
+        assert_eq!(should_scan_file::<RustProject>("foo.rss"), false);
+        assert_eq!(should_scan_file::<RustProject>("foo.js"), false);
+        assert_eq!(should_scan_file::<RustProject>("Cargo.toml"), false);
+        assert_eq!(should_scan_file::<RustProject>("Cargo.lock"), false);
+        assert_eq!(should_scan_file::<RustProject>("foo.toml"), false);
+    }
 }

--- a/src/project/node_js.rs
+++ b/src/project/node_js.rs
@@ -1,12 +1,8 @@
-use std::{collections::HashMap, env, fs::File};
-
-use crate::file_handler::read_file;
+use std::collections::HashMap;
 
 use super::Project;
 
 use serde::Deserialize;
-
-const DEPS_FILE: &str = "package.json";
 
 #[derive(Deserialize)]
 #[serde(rename_all = "camelCase")]
@@ -17,75 +13,30 @@ pub struct NodePackagesHandler {
 
 pub struct NodeProject {
     deps: Vec<String>,
-
-    allowed_extensions: Vec<String>,
-    excluded_paths: Vec<String>,
 }
 
 impl NodeProject {
-    fn new(allowed_extensions: Vec<String>, excluded_paths: Vec<String>) -> Self {
+    pub fn new() -> Self {
         Self {
-            allowed_extensions,
-            excluded_paths,
-            deps: vec![],
+            deps: Vec::new()
         }
     }
 }
 
 impl Project for NodeProject {
-    fn default() -> Self {
-        Self::new(
-            vec![
-                "js".into(),
-                "jsx".into(),
-                "ts".into(),
-                "tsx".into(),
-                "scss".into(),
-                "sass".into(),
-                "json".into(),
-            ],
-            vec!["package.json".into(), "node_modules/".into()],
-        )
-    }
+    const DEPS_FILE: &str = "package.json";
+    const ALLOWED_EXTENSIONS: &[&str] = &["js", "jsx", "ts", "tsx", "scss", "sass", "json"];
+    const EXCLUDED_PATHS: &[&str] = &["package.json", "node_modules/"];
 
     fn parse_deps(&mut self, deps_file_content: &str) -> usize {
         let packages_handler: NodePackagesHandler = serde_json::from_str(deps_file_content)
-            .unwrap_or_else(|_| panic!("Cannot parse {DEPS_FILE} file."));
+            .unwrap_or_else(|e| panic!("Cannot parse {} file. {e}", NodeProject::DEPS_FILE));
         self.deps = get_deps_names(packages_handler);
         self.deps.len()
     }
 
-    // TODO should_scan_file functions are exactly the same for both projects
-    fn should_scan_file(&self, file_path: &str) -> bool {
-        if file_path == "." {
-            return true;
-        }
-
-        for excluded in self.excluded_paths.iter() {
-            if file_path.contains(excluded) {
-                return false;
-            }
-        }
-        for ext in self.allowed_extensions.iter() {
-            if file_path.ends_with(&format!(".{ext}")) {
-                return true;
-            }
-        }
-        false
-    }
-
     fn deps(&self) -> &Vec<String> {
         &self.deps
-    }
-
-    fn read_deps_file() -> String {
-        let f = File::open(DEPS_FILE).unwrap_or_else(|_| {
-            panic!(
-                "No file \"{DEPS_FILE}\" in {}",
-                env::current_dir().unwrap().display()
-            )
-        });
-        read_file(f).unwrap_or_else(|_| panic!("Cannot read {DEPS_FILE} file."))
     }
 }
 
@@ -121,34 +72,6 @@ mod project_node_tests {
     use super::*;
 
     #[test]
-    fn should_scan_file_works() {
-        let project = NodeProject::default();
-        assert_eq!(project.should_scan_file("foo.js"), true);
-        assert_eq!(project.should_scan_file("foo.ts"), true);
-        assert_eq!(project.should_scan_file("foo.tsx"), true);
-        assert_eq!(project.should_scan_file("foo.jsx"), true);
-        assert_eq!(project.should_scan_file("foo.rs"), false);
-        assert_eq!(project.should_scan_file("foo.jssx"), false);
-        assert_eq!(project.should_scan_file("package.json"), false);
-        assert_eq!(project.should_scan_file("foo/node_modules/foo.ts"), false);
-
-        let project = NodeProject::new(vec![String::from("js")], Vec::new());
-        assert_eq!(project.should_scan_file("foo.js"), true);
-        assert_eq!(project.should_scan_file("foo.ts"), false);
-        assert_eq!(project.should_scan_file("foo.jsx"), false);
-
-        let project = NodeProject::new(
-            vec![String::from("ts")],
-            vec![String::from("bar.ts"), String::from("node_modules/")],
-        );
-        assert_eq!(project.should_scan_file("foo/bar/foo.ts"), true);
-        assert_eq!(project.should_scan_file("foo/bar/bar.ts"), false);
-        assert_eq!(project.should_scan_file("bar.ts"), false);
-        assert_eq!(project.should_scan_file("foo/bar/package.json"), false);
-        assert_eq!(project.should_scan_file("foo/node_modules/foo.ts"), false);
-    }
-
-    #[test]
     fn get_deps_names_works() {
         let mut packages_handler = NodePackagesHandler {
             dependencies: HashMap::new(),
@@ -169,7 +92,7 @@ mod project_node_tests {
 
     #[test]
     fn parse_deps_works() {
-        let mut project = NodeProject::default();
+        let mut project = NodeProject::new();
 
         let file_content = "{
         \"name\": \"foo\",

--- a/src/project/rust.rs
+++ b/src/project/rust.rs
@@ -1,13 +1,7 @@
-use std::{env, fs::File};
-
 use serde::Deserialize;
 use toml::Table;
 
-use crate::file_handler::read_file;
-
 use super::Project;
-
-const DEPS_FILE: &str = "Cargo.toml";
 
 #[derive(Deserialize)]
 pub struct RustPackagesHandler {
@@ -16,70 +10,30 @@ pub struct RustPackagesHandler {
 
 pub struct RustProject {
     deps: Vec<String>,
-
-    allowed_extensions: Vec<String>,
-    excluded_paths: Vec<String>,
 }
 
 impl RustProject {
-    fn new(allowed_extensions: Vec<String>, excluded_paths: Vec<String>) -> Self {
+    pub fn new() -> Self {
         Self {
-            allowed_extensions,
-            excluded_paths,
-            deps: Vec::new(),
+            deps: Vec::new()
         }
     }
 }
 
 impl Project for RustProject {
-    fn default() -> Self {
-        Self::new(
-            Vec::from(["rs".into()]),
-            // For now, excluding Cargo.toml file is not necessary but if in the future we need to
-            // include .toml files then we can't miss it.
-            Vec::from(["Cargo.toml".into()]),
-        )
-    }
+    const DEPS_FILE: &str = "Cargo.toml";
+    const ALLOWED_EXTENSIONS: &[&str] = &["rs"];
+    const EXCLUDED_PATHS: &[&str] = &["Cargo.toml"];
 
     fn parse_deps(&mut self, deps_file_content: &str) -> usize {
         let packages_handler: RustPackagesHandler = toml::from_str(deps_file_content)
-            .unwrap_or_else(|e| panic!("Cannot parse {DEPS_FILE} file. {}", e));
+            .unwrap_or_else(|e| panic!("Cannot parse {} file. {e}", RustProject::DEPS_FILE));
         self.deps = get_deps_names(packages_handler);
         self.deps.len()
     }
 
-    // TODO should_scan_file functions are exactly the same for both projects
-    fn should_scan_file(&self, file_path: &str) -> bool {
-        if file_path == "." {
-            return true;
-        }
-
-        for excluded in self.excluded_paths.iter() {
-            if file_path.contains(excluded) {
-                return false;
-            }
-        }
-        for ext in self.allowed_extensions.iter() {
-            if file_path.ends_with(&format!(".{ext}")) {
-                return true;
-            }
-        }
-        false
-    }
-
     fn deps(&self) -> &Vec<String> {
         &self.deps
-    }
-
-    // TODO Always same function, need to be refactored
-    fn read_deps_file() -> String {
-        let f = File::open(DEPS_FILE).unwrap_or_else(|_| {
-            panic!(
-                "No file \"{DEPS_FILE}\" in {}",
-                env::current_dir().unwrap().display()
-            )
-        });
-        read_file(f).unwrap_or_else(|_| panic!("Cannot read {DEPS_FILE} file."))
     }
 }
 
@@ -99,15 +53,6 @@ mod project_rust_tests {
     use super::*;
 
     #[test]
-    fn should_scan_file_works() {
-        let project = RustProject::default();
-        assert_eq!(project.should_scan_file("foo.rs"), true);
-        assert_eq!(project.should_scan_file("foo.js"), false);
-        assert_eq!(project.should_scan_file("Cargo.toml"), false);
-        assert_eq!(project.should_scan_file("Cargo.lock"), false);
-    }
-
-    #[test]
     fn get_deps_names_works() {
         let mut packages_handler = RustPackagesHandler {
             dependencies: Table::new(),
@@ -124,7 +69,7 @@ mod project_rust_tests {
 
     #[test]
     fn parse_deps_works() {
-        let mut project = RustProject::default();
+        let mut project = RustProject::new();
 
         let file_content = "[dependencies]
             foo = \"2.1.0\"


### PR DESCRIPTION
Moved functions :
  * should_scan_file
  * read_deps_file

Add those constants in Project trait :
    const DEPS_FILE: &str;
    const ALLOWED_EXTENSIONS: &[&str];
    const EXCLUDED_PATHS: &[&str];
